### PR TITLE
This commit is for role definition and register #7 and #8

### DIFF
--- a/app/public/wp-content/themes/student-survey-child/inc/auth-redirect.php
+++ b/app/public/wp-content/themes/student-survey-child/inc/auth-redirect.php
@@ -1,15 +1,14 @@
+<!-- // Restrict access to admin pages for non-admins -->
 <?php
+
 // Login redirect by role
 add_filter('login_redirect', function($redirect_to, $request, $user) {
     if ($user instanceof WP_User && !empty($user->roles)) {
         if (in_array('administrator', $user->roles, true)) {
             return admin_url();
         }
-        if (in_array('teacher', $user->roles, true)) {
+        if (in_array('teacher', $user->roles, true) || in_array('instructor', $user->roles, true)) {
             return home_url('/dashboard/teacher/');
-        }
-        if (in_array('instructor', $user->roles, true)) {
-            return admin_url();
         }
         if (in_array('student', $user->roles, true)) {
             return home_url('/student-dashboard');
@@ -24,12 +23,40 @@ add_action('wp_logout', function() {
     exit;
 });
 
-// Block wp-admin for students
+// Block wp-admin for students and instructors (no admin for eux)
 add_action('admin_init', function() {
     if ( is_admin() && !defined('DOING_AJAX') ) {
         $user = wp_get_current_user();
         if ( in_array('student', (array) $user->roles) ) {
             wp_redirect(home_url('/student-dashboard'));
+            exit;
+        }
+        if ( in_array('teacher', (array) $user->roles) || in_array('instructor', (array) $user->roles) ) {
+            wp_redirect(home_url('/dashboard/teacher/'));
+            exit;
+        }
+    }
+});
+
+add_action('template_redirect', function() {
+    if (is_page('admin-only')) {
+        $user = wp_get_current_user();
+        if (!in_array('administrator', (array) $user->roles)) {
+            wp_redirect(home_url('/'));
+            exit;
+        }
+    }
+    if (is_page('instructor-only')) {
+        $user = wp_get_current_user();
+        if (!in_array('teacher', (array) $user->roles) && !in_array('instructor', (array) $user->roles)) {
+            wp_redirect(home_url('/'));
+            exit;
+        }
+    }
+    if (is_page('student-only')) {
+        $user = wp_get_current_user();
+        if (!in_array('student', (array) $user->roles)) {
+            wp_redirect(home_url('/'));
             exit;
         }
     }

--- a/app/public/wp-content/themes/student-survey-child/inc/dynamic-menu.php
+++ b/app/public/wp-content/themes/student-survey-child/inc/dynamic-menu.php
@@ -7,21 +7,23 @@ add_shortcode('dynamic_main_menu', function() {
     if (!is_user_logged_in()) {
         $menu[] = '<div class="dynamic-menu-dropdown"><a href="#">User</a><div class="dynamic-menu-dropdown-content">'
             .'<a href="' . esc_url(wp_login_url()) . '">Login</a>'
-            .'<a href="' . esc_url(wp_registration_url()) . '">Register</a>'
+            .'<a href="' . esc_url(wp_registration_url()) . '">Register as Student</a>'
             .'</div></div>';
     } else {
         $user = wp_get_current_user();
         $dashboard = '';
+        $role_label = '';
         if (in_array('administrator', $user->roles)) {
             $dashboard = home_url('/dashboard/');
-        } elseif (in_array('teacher', $user->roles)) {
+            $role_label = 'Admin';
+        } elseif (in_array('teacher', $user->roles) || in_array('instructor', $user->roles)) {
             $dashboard = home_url('/dashboard/teacher/');
-        } elseif (in_array('instructor', $user->roles)) {
-            $dashboard = home_url('/dashboard/instructor/');
+            $role_label = 'Instructor';
         } elseif (in_array('student', $user->roles)) {
             $dashboard = home_url('/student-dashboard');
+            $role_label = 'Student';
         }
-        $menu[] = '<div class="dynamic-menu-dropdown"><a href="#">User</a><div class="dynamic-menu-dropdown-content">'
+        $menu[] = '<div class="dynamic-menu-dropdown"><a href="#">' . esc_html($role_label) . '</a><div class="dynamic-menu-dropdown-content">'
             .'<a href="' . esc_url(get_edit_profile_url($user->ID)) . '">Profile</a>'
             .($dashboard ? '<a href="' . esc_url($dashboard) . '">Dashboard</a>' : '')
             .'<a href="' . esc_url(wp_logout_url(home_url('/'))) . '">Logout</a>'

--- a/app/public/wp-content/themes/student-survey-child/inc/roles.php
+++ b/app/public/wp-content/themes/student-survey-child/inc/roles.php
@@ -1,22 +1,50 @@
+<!-- // Autoriser l'inscription publique pour les étudiants -->
 <?php
 // Custom roles: Student, Teacher, Instructor
 // Uncomment if you want to (re)create roles on theme load
 add_action('init', function() {
+    // Student: accès limité, feedback, lecture
     if (!get_role('student')) {
-        add_role('student', 'Student', array('read' => true));
+        add_role('student', 'Student', array(
+            'read' => true,
+            'edit_posts' => false,
+            'edit_surveys' => false,
+            'manage_users' => false,
+        ));
     }
+    // Teacher: créer/éditer surveys, gérer ses classes
     if (!get_role('teacher')) {
-        add_role('teacher', 'Teacher', array('read' => true, 'edit_posts' => true));
+        add_role('teacher', 'Instructor', array(
+            'read' => true,
+            'edit_posts' => true,
+            'edit_surveys' => true,
+            'manage_classes' => true,
+            'manage_users' => false,
+        ));
     }
+    // Instructor: identique à teacher (pour compatibilité)
     if (!get_role('instructor')) {
-        add_role('instructor', 'Instructor', array('read' => true));
+        add_role('instructor', 'Instructor', array(
+            'read' => true,
+            'edit_posts' => true,
+            'edit_surveys' => true,
+            'manage_classes' => true,
+            'manage_users' => false,
+        ));
+    }
+    // Admin: tout accès (WordPress natif)
+    // On peut ajouter des capacités custom si besoin
+});
+
+add_action('init', function() {
+    if (get_option('users_can_register') != 1) {
+        update_option('users_can_register', 1);
     }
 });
 
-// Force default role "student" on registration
 add_action('user_register', function($user_id) {
     $user = new WP_User($user_id);
-    if ($user && !in_array('student', $user->roles, true)) {
+    if ($user) {
         $user->set_role('student');
     }
 });


### PR DESCRIPTION
## 🔹 Summary
Adds custom user roles and post‑login redirects to improve access control and user experience in the **Student Survey** WordPress plugin.

### ✨ Key Features
- **New Roles:** `student`, `teacher`/`instructor` with tailored capabilities  
- **Auto‑Assignment:** Public registrations automatically get the `student` role  
- **Self‑Registration Enabled:** Users can create their own accounts  
- **Role‑Based Redirects:**  
  - **Admin** → WordPress Dashboard  
  - **Teacher/Instructor** → `/dashboard/teacher/`  
  - **Student** → `/student-dashboard`  
- **Restricted Access:** Non‑admins are blocked from `/wp-admin` and redirected  
- **Page‑Level Permissions:** Access to certain pages enforced by role  
- **Dynamic User Menu:** Displays role and relevant quick links  

<img width="687" height="750" alt="image" src="https://github.com/user-attachments/assets/357be3a4-1667-4d42-8a73-20f9ca156432" />