### PR TITLE
Home Page Context and Dynamic Menu Improvements

### DIFF
--- a/app/public/wp-content/themes/student-survey-child/inc/dynamic-menu.php
+++ b/app/public/wp-content/themes/student-survey-child/inc/dynamic-menu.php
@@ -2,7 +2,18 @@
 // Dynamic main menu shortcode
 add_shortcode('dynamic_main_menu', function() {
     $menu = array();
-    $menu[] = '<a href="' . esc_url(home_url('/')) . '">Home</a>';
+    // Lien dynamique pour la page d'accueil contextuelle
+    $home_context_page = get_pages(array(
+        'meta_key' => '_wp_page_template',
+        'meta_value' => 'page-home-context.php',
+        'post_status' => 'publish',
+        'number' => 1
+    ));
+    if (!empty($home_context_page)) {
+        $menu[] = '<a href="' . esc_url(get_permalink($home_context_page[0]->ID)) . '">' . esc_html(get_the_title($home_context_page[0]->ID)) . '</a>';
+    } else {
+        $menu[] = '<a href="' . esc_url(home_url('/')) . '">Home</a>';
+    }
     $menu[] = '<a href="' . esc_url(home_url('/about/')) . '">Abouts</a>';
     if(is_user_logged_in() && current_user_can('student')) {
         $menu[] = '<a href="' . esc_url(home_url('/survey/')) . '">All Surveys</a>';

--- a/app/public/wp-content/themes/student-survey-child/page-home-context.php
+++ b/app/public/wp-content/themes/student-survey-child/page-home-context.php
@@ -1,0 +1,14 @@
+<?php
+/*
+Template Name: Home Context
+*/
+get_header();
+?>
+<div class="home-context-container" style="max-width:800px;margin:40px auto 0 auto;padding:32px 24px;background:#fff;border-radius:12px;box-shadow:0 2px 16px rgba(0,0,0,0.07);">
+    <h1 style="color:#0073aa;font-size:2em;font-weight:700;text-align:center;margin-bottom:24px;">Welcome to the Student Survey App Platform</h1>
+    <p style="font-size:1.1em;line-height:1.7;margin-bottom:24px;">
+        This application is designed to make it easy to manage and participate in student surveys. Instructors can create custom surveys, while students can respond and track their participation. The goal is to encourage student feedback and improve the educational experience through constructive input.
+    </p>
+</div>
+<?php
+get_footer();


### PR DESCRIPTION
- Added a custom page template for the project context and blog introduction.
- Made the main menu “Home” link dynamic: it now points to the page using the home context template, regardless of its slug or title.
- The menu displays the actual page title for the home link.
- Instructions: Set the page using the “Home Context” template as the static front page in WordPress settings to display it at /.
- This ensures all collaborators see the correct homepage content and navigation, no matter their local page slugs.

After doing `git pull`, if you want to implemente this, look at the procedure on screenshort below:

1. create a simple page

<img width="1933" height="871" alt="12" src="https://github.com/user-attachments/assets/d7094e4b-9fda-4d91-b472-4a6b720b6038" />

2. Add a title

<img width="1917" height="870" alt="13" src="https://github.com/user-attachments/assets/9caf6910-2e2d-4348-98eb-16be83441d1b" />

3. to Pages List

https://github.com/user-attachments/assets/fc93493c-d76f-499b-aa61-1b6a69caf2a8

and if you want to see the Home page after login, do this:

<img width="1930" height="867" alt="image" src="https://github.com/user-attachments/assets/4d9a1a6f-c020-4acc-b4d9-9d86b1dd315a" />

